### PR TITLE
remove calls to net/url Parse as it is ambiguous

### DIFF
--- a/db.go
+++ b/db.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"net/url"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -81,13 +80,6 @@ func (db *DB) Wait() error {
 
 // Open will attempt to open a new database connection.
 func Open(driverName, dsn string) (*DB, error) {
-	uri, err := url.Parse(fmt.Sprintf("%s://%s", driverName, dsn))
-	if err != nil {
-		log.Printf("could not parse database dsn\n")
-	} else {
-		log.Printf("opening database connection: %s (%s)\n", uri.Host, driverName)
-	}
-
 	switch driverName {
 	case "mysql":
 	default:
@@ -133,13 +125,6 @@ func MustOpen(driverName, dsn string) *DB {
 // OpenMigration will open a migration instance.
 func OpenMigration(driverName, dsn, sourceURL string) (*migrate.Migrate, error) {
 	dsn = fmt.Sprintf("%s://%s", driverName, dsn)
-	uri, err := url.Parse(dsn)
-	if err != nil {
-		log.Printf("could not parse database dsn\n")
-	} else {
-		log.Printf("opening database migration: %s (%s)\n", uri.Host, driverName)
-	}
-
 	migration, err := migrate.New(sourceURL, dsn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When working with a DSN, parsing results can't be really trusted
and therefore shouldn't be relied upon. Validating the url should
be left to wether or not we acquire a working connection.