### PR TITLE
add automatic promethues metrics for roundtrip db query times

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/golang-migrate/migrate/v4 v4.2.5
+	github.com/prometheus/client_golang v1.2.1
 )


### PR DESCRIPTION
This change adds a prometheus Histogram to each database connection. The
promauto.Histogram will automatically register with the default
prometheus client, if one exists. This change also adds a set of methods
to the the coresql.DB that override the Exec/Query methods of the
underlying sql.DB. These methods record, to the prometheus histogram, the
duration of the Exec/Query call to the underlying sql.DB.

If the application uses the core metrics server from
LUSHDigital/core/workers/metricsrv, the database histogram will be available
via that metrics server's endpoint without any further changes to your
code.