### PR TITLE
fix: use more accurate tables statement

### DIFF
--- a/sqltest/generic.go
+++ b/sqltest/generic.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	truncateStmtFmt = "TRUNCATE TABLE %s"
-	showTablesStmt  = "SHOW TABLES"
+	showTablesStmt  = "SELECT table_name FROM information_schema.tables WHERE table_type = 'BASE TABLE'"
 )
 
 var (


### PR DESCRIPTION
To avoid errors with views, we should select from the `information_scheme.tables` table and select only tables when we truncate. This MR fixes this by using an more specific select statement.